### PR TITLE
Fix positions tab rendering indentation

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,8 +11,11 @@ try:
 except Exception:
     pass
 
-# DPI policy first
-QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(Qt.HighDpiScaleFactorRoundingPolicy.PassThrough)
+# DPI policy first (only if no application exists yet)
+if QtGui.QGuiApplication.instance() is None:
+    QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
+        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+    )
 
 # Version banner
 from app import preamble  # noqa: F401
@@ -24,7 +27,12 @@ def main():
     app = QApplication(sys.argv)
     try:
         app.setApplicationDisplayName("Binance Trading Bot")
-        app.setWindowIcon(QtGui.QIcon(str(_P(__file__).resolve().parent / 'app' / 'assets' / 'binance_icon.ico')))
+        assets_dir = _P(__file__).resolve().parent / 'app' / 'assets'
+        icon = QtGui.QIcon(str(assets_dir / 'binance_icon.ico'))
+        if icon.isNull():
+            icon = QtGui.QIcon(str(assets_dir / 'binance_icon.png'))
+        if not icon.isNull():
+            app.setWindowIcon(icon)
     except Exception:
         pass
     win = MainWindow()


### PR DESCRIPTION
## Summary
- ensure the desktop icon loads from the Binance assets and guard the high DPI policy call to avoid startup warnings
- simplify the positions tab into a single read-only table with accurate margin ratios and per-symbol close buttons while removing the closed history block
- keep theme switching to Light/Dark, reuse the Binance wrapper for close actions, and downgrade the margin-type log noise when it is already set
- refactor the positions table renderer to remove the stray indentation that caused import-time crashes on Windows

## Testing
- python -m compileall main.py app/binance_wrapper.py app/gui/main_window.py


------
https://chatgpt.com/codex/tasks/task_e_68db89e19c548325a269e15e6ec81a2f