### PR TITLE
Fix positions tab metrics and DPI warning

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,8 @@
+import os
 import sys
+
+# Ensure Qt uses pass-through DPI rounding even when the helper is unavailable.
+os.environ.setdefault("QT_SCALE_FACTOR_ROUNDING_POLICY", "PassThrough")
 
 from PyQt6 import QtGui
 from PyQt6.QtCore import Qt
@@ -10,12 +14,6 @@ try:
     ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("Binance.TradingBot")
 except Exception:
     pass
-
-# DPI policy first (only if no application exists yet)
-if QtGui.QGuiApplication.instance() is None:
-    QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
-        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
-    )
 
 # Version banner
 from app import preamble  # noqa: F401


### PR DESCRIPTION
## Summary
- include the raw futures position metadata in the background worker so the positions table can compute margin ratio and timestamps
- augment the UI refresh logic to reuse cached trade intervals/times and format timestamp values for display in the second tab
- rely on the Qt rounding-policy environment variable and deduplicate margin-mode logs to remove noisy warnings

## Testing
- python -m compileall app main.py

------
https://chatgpt.com/codex/tasks/task_e_68dd026093c883258773b25f450524fe