### PR TITLE
Improve positions tab accuracy and UI locking

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,10 @@
+import os
 import sys
 
-from PyQt6 import QtGui
+# Ensure Qt uses pass-through DPI rounding even when the helper is unavailable.
+os.environ.setdefault("QT_SCALE_FACTOR_ROUNDING_POLICY", "PassThrough")
+
+from PyQt6 import QtGui, QtCore
 from PyQt6.QtCore import Qt
 from PyQt6.QtWidgets import QApplication
 
@@ -11,12 +15,6 @@ try:
 except Exception:
     pass
 
-# DPI policy first (only if no application exists yet)
-if QtGui.QGuiApplication.instance() is None:
-    QtGui.QGuiApplication.setHighDpiScaleFactorRoundingPolicy(
-        Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
-    )
-
 # Version banner
 from app import preamble  # noqa: F401
 
@@ -24,6 +22,13 @@ from app.gui.main_window import MainWindow
 from pathlib import Path as _P
 
 def main():
+    try:
+        QtCore.QCoreApplication.setHighDpiScaleFactorRoundingPolicy(
+            QtCore.Qt.HighDpiScaleFactorRoundingPolicy.PassThrough
+        )
+    except Exception:
+        pass
+
     app = QApplication(sys.argv)
     try:
         app.setApplicationDisplayName("Binance Trading Bot")


### PR DESCRIPTION
## Summary
- merge multiple Binance futures endpoints so the positions worker reports accurate margin ratios and timing metadata without noisy margin-type warnings
- surface entry timeframe/time for each position and append closed trades as "Closed" history rows in the positions table
- gate dashboard controls while strategies run and set the Qt DPI rounding policy before QApplication to suppress startup errors

## Testing
- python -m compileall app main.py

------
https://chatgpt.com/codex/tasks/task_e_68dd026093c883258773b25f450524fe